### PR TITLE
feat: Update cargo dependencies bevy_webgl2 only when target wasm32

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ web = [
 
 [dependencies]
 bevy = {version="0.4.0", default-features=false}
+[target.'cfg(target_arch = "wasm32")'.dependencies]
 bevy_webgl2 = {version="0.4.0", optional=true}
 
 winit = {version = "0.24.0"}


### PR DESCRIPTION
Make dependence bevy_webgl2 only used when compiling to wasm32.

This is done so rustanalyzer analyze and errors on it, resulting on being not usable.
The error in question:
```
bevy_webgl2-0.4.3/src/renderer/webgl2_render_resource_context.rs

unresolved import `winit::platform::web`
could not find `web` in `platform`
```